### PR TITLE
dev-lang/rust-1.20.0: Fix USE=-system-llvm

### DIFF
--- a/dev-lang/rust/rust-1.20.0.ebuild
+++ b/dev-lang/rust/rust-1.20.0.ebuild
@@ -136,7 +136,7 @@ src_configure() {
 
 src_compile() {
 	export RUST_BACKTRACE=1
-	export LLVM_LINK_SHARED=1
+	use system-llvm && export LLVM_LINK_SHARED=1
 
 	./x.py build --verbose --config="${S}"/config.toml || die
 }


### PR DESCRIPTION
correct use system-llvm behaviour